### PR TITLE
Fixed multiple things

### DIFF
--- a/dmcp/bcd.py
+++ b/dmcp/bcd.py
@@ -212,9 +212,9 @@ def proximal_op(prob, var_slack, lambd):
         # add quadratic terms for all variables that are not slacks
         if not var.id in slack_id:
             if prob.objective.NAME == 'minimize':
-                new_cost = new_cost + cvx.square(cvx.norm(var - var.value, 2))/2/lambd
+                new_cost = new_cost + cvx.square(cvx.norm(cvx.vec(var - var.value), 2))/2/lambd
             else:
-                new_cost = new_cost - cvx.square(cvx.norm(var - var.value, 2))/2/lambd
+                new_cost = new_cost - cvx.square(cvx.norm(cvx.vec(var - var.value), 2))/2/lambd
 
     # Define proximal problem
     if prob.objective.NAME == 'minimize':

--- a/dmcp/bcd.py
+++ b/dmcp/bcd.py
@@ -90,7 +90,6 @@ def _bcd(prob, fix_sets, max_iter, solver, mu, rho, mu_max, ep, lambd, linear, p
     :return: it: number of iterations; max_slack: maximum slack variable
     """
     obj_pre = np.inf
-    print("Hi", fix_sets)
     for it in range(max_iter):
         np.random.shuffle(fix_sets)
         #print "======= iteration", it, "======="
@@ -111,14 +110,11 @@ def _bcd(prob, fix_sets, max_iter, solver, mu, rho, mu_max, ep, lambd, linear, p
             # add slack variables
             fixed_p, var_slack = add_slack(fixed_p, mu)
             # proximal operator
-            print("HI HI HI HI")
             if proximal:
                 fixed_p = proximal_op(fixed_p, var_slack, lambd)
-            print("Bye Bye Bye Bye")
             # solve
             fixed_p.solve(solver = solver)
             max_slack = 0
-            print("HELLO", [var.value for var in var_slack])
             if not var_slack == []:
                 max_slack = np.max([np.max(np.abs(var.value)) for var in var_slack])
                 print("max abs slack =", max_slack, "mu =", mu, "original objective value =", prob.objective.args[0].value, "fixed objective value =",fixed_p.objective.args[0].value, "status=", fixed_p.status)

--- a/dmcp/bcd.py
+++ b/dmcp/bcd.py
@@ -90,6 +90,7 @@ def _bcd(prob, fix_sets, max_iter, solver, mu, rho, mu_max, ep, lambd, linear, p
     :return: it: number of iterations; max_slack: maximum slack variable
     """
     obj_pre = np.inf
+    print("Hi", fix_sets)
     for it in range(max_iter):
         np.random.shuffle(fix_sets)
         #print "======= iteration", it, "======="
@@ -110,13 +111,16 @@ def _bcd(prob, fix_sets, max_iter, solver, mu, rho, mu_max, ep, lambd, linear, p
             # add slack variables
             fixed_p, var_slack = add_slack(fixed_p, mu)
             # proximal operator
+            print("HI HI HI HI")
             if proximal:
                 fixed_p = proximal_op(fixed_p, var_slack, lambd)
+            print("Bye Bye Bye Bye")
             # solve
             fixed_p.solve(solver = solver)
             max_slack = 0
+            print("HELLO", [var.value for var in var_slack])
             if not var_slack == []:
-                max_slack = np.max([np.max(cvx.abs(var).value) for var in var_slack])
+                max_slack = np.max([np.max(np.abs(var.value)) for var in var_slack])
                 print("max abs slack =", max_slack, "mu =", mu, "original objective value =", prob.objective.args[0].value, "fixed objective value =",fixed_p.objective.args[0].value, "status=", fixed_p.status)
             else:
                 print("original objective value =", prob.objective.args[0].value, "status=", fixed_p.status)
@@ -212,9 +216,9 @@ def proximal_op(prob, var_slack, lambd):
         # add quadratic terms for all variables that are not slacks
         if not var.id in slack_id:
             if prob.objective.NAME == 'minimize':
-                new_cost = new_cost + cvx.square(cvx.norm(var - var.value,'fro'))/2/lambd
+                new_cost = new_cost + cvx.square(cvx.norm(var - var.value, 2))/2/lambd
             else:
-                new_cost = new_cost - cvx.square(cvx.norm(var - var.value,'fro'))/2/lambd
+                new_cost = new_cost - cvx.square(cvx.norm(var - var.value, 2))/2/lambd
 
     # Define proximal problem
     if prob.objective.NAME == 'minimize':

--- a/dmcp/find_set.py
+++ b/dmcp/find_set.py
@@ -32,6 +32,14 @@ def find_minimal_sets(prob, is_all = False):
         V.sort()
         fix_idx = [V.index(varid) for varid in fix_id]
         result.append(fix_idx)
+    
+    # TODO. Quick fix. Will fix algorithm later on
+    if result == []:
+        for var in prob.variables():
+            fix_var = [avar.id for avar in prob.variables() if not avar.id == var.id]
+            fix_var.sort()
+            result.append(fix_var)
+
     return result
 
 def find_MIS(prob, is_all):

--- a/dmcp/find_set.py
+++ b/dmcp/find_set.py
@@ -6,6 +6,7 @@ __author__ = 'Xinyue'
 
 from dmcp import fix
 from dmcp import is_atom_multiconvex
+from dmcp import is_dmcp
 import numpy as np
 from cvxpy.expressions.leaf import Leaf
 from cvxpy.expressions.variable import Variable
@@ -34,7 +35,7 @@ def find_minimal_sets(prob, is_all = False):
         result.append(fix_idx)
     
     # TODO. Quick fix. Will fix algorithm later on
-    if result == []:
+    if result == [] and not prob.is_dcp() and is_dmcp(prob):
         for var in prob.variables():
             fix_var = [avar.id for avar in prob.variables() if not avar.id == var.id]
             fix_var.sort()

--- a/dmcp/find_set.py
+++ b/dmcp/find_set.py
@@ -35,11 +35,11 @@ def find_minimal_sets(prob, is_all = False):
         result.append(fix_idx)
     
     # TODO. Quick fix. Will fix algorithm later on
-    if result == [] and not prob.is_dcp() and is_dmcp(prob):
-        for var in prob.variables():
-            fix_var = [avar.id for avar in prob.variables() if not avar.id == var.id]
-            fix_var.sort()
-            result.append(fix_var)
+    #if result == [] and not prob.is_dcp() and is_dmcp(prob):
+    #    for var in prob.variables():
+    #        fix_var = [avar.id for avar in prob.variables() if not avar.id == var.id]
+    #        fix_var.sort()
+    #        result.append(fix_var)
 
     return result
 
@@ -99,6 +99,7 @@ def find_all_iset(V,g):
     :return: a list of independent subsets
     """
     subsets = find_all_subsets(V)
+    subsets.append([])
     result = []
     V_id = [var.id for var in V]
     V_id.sort()
@@ -106,9 +107,10 @@ def find_all_iset(V,g):
         subset_id = [var.id for var in subset]
         subset_id.sort()
         subset_ind = [V_id.index(i) for i in subset_id]
-        var_set_ind = [i for i in range(len(V_id))]
-        set_complement = list(set(var_set_ind).difference(set(subset_ind)))
-        if is_independent(set_complement, g) and not set_complement == []:
+        #var_set_ind = [i for i in range(len(V_id))]
+        #set_complement = list(set(var_set_ind).difference(set(subset_ind)))
+        #if is_independent(set_complement, g) and not set_complement == []:
+        if is_independent(subset_ind, g):
             result.append(subset)
     return result
 

--- a/dmcp/find_set.py
+++ b/dmcp/find_set.py
@@ -6,7 +6,6 @@ __author__ = 'Xinyue'
 
 from dmcp import fix
 from dmcp import is_atom_multiconvex
-from dmcp import is_dmcp
 import numpy as np
 from cvxpy.expressions.leaf import Leaf
 from cvxpy.expressions.variable import Variable
@@ -34,7 +33,7 @@ def find_minimal_sets(prob, is_all = False):
         fix_idx = [V.index(varid) for varid in fix_id]
         result.append(fix_idx)
     
-    # TODO. Quick fix. Will fix algorithm later on
+    # Already fixed.
     #if result == [] and not prob.is_dcp() and is_dmcp(prob):
     #    for var in prob.variables():
     #        fix_var = [avar.id for avar in prob.variables() if not avar.id == var.id]

--- a/dmcp/initial.py
+++ b/dmcp/initial.py
@@ -19,8 +19,10 @@ def rand_initial(prob):
             dummy = np.asmatrix(np.random.standard_normal(var.shape))
             matrix = dummy.T*dummy
             var.value = np.asarray(matrix)
-        else:
+        elif var.sign == "NONPOSITIVE":
             var.value = -np.abs(np.random.standard_normal(var.shape))
+        else:
+            var.value = np.random.standard_normal(var.shape)
 
 def rand_initial_proj(self, times = 1, random = 1):
     """

--- a/examples/EM.py
+++ b/examples/EM.py
@@ -169,17 +169,20 @@ variable_dict = get_variables(data_dim, num_classes, num_examples)
 objective = get_objective(partitioned_set, variable_dict, data_dim, num_classes, num_examples)
 constraints = get_constraints(partitioned_set, variable_dict, data_dim, num_classes, num_examples)
 problem = cvx.Problem(objective, constraints)
-fix_var = [var[0,0] for var in variable_dict.values() if not var == variable_dict['inverse_conditional']]
-fix_var2 = [var[0,0] for var in variable_dict.values() if not var == variable_dict['precision']]
-print("Variable ID of Conditional is", variable_dict['inverse_conditional'][0,0].id)
-print("Variable ID of Precision is", variable_dict['precision'][0,0].id)
-print("Fix_var is", [var.id for var in fix_var])
-print("Conditional Is_DMCP", dmcp.is_dmcp(dmcp.fix(problem, fix_var)))
-print("Conditional Is_DCP", dmcp.fix(problem, fix_var).is_dcp())
-print("Precision Is_DMCP", dmcp.is_dmcp(dmcp.fix(problem, fix_var2)))
-print("Precision Is_DCP", dmcp.fix(problem, fix_var2).is_dcp())
-print("Objective DMCP", dmcp.is_dmcp(objective.expr))
-print("Is Problem DMCP? ", dmcp.is_dmcp(problem))
-print("Number of variables: ", len(problem.variables()))
 
-result = problem.solve(method = 'bcd', update = 'proximal', solver=cvx.MOSEK, max_iter=100)
+
+# fix_var = [var[0,0] for var in variable_dict.values() if not var == variable_dict['inverse_conditional']]
+# fix_var2 = [var[0,0] for var in variable_dict.values() if not var == variable_dict['precision']]
+# print("Variable ID of Conditional is", variable_dict['inverse_conditional'][0,0].id)
+# print("Variable ID of Precision is", variable_dict['precision'][0,0].id)
+# print("Fix_var is", [var.id for var in fix_var])
+# print("Conditional Is_DMCP", dmcp.is_dmcp(dmcp.fix(problem, fix_var)))
+# print("Conditional Is_DCP", dmcp.fix(problem, fix_var).is_dcp())
+# print("Precision Is_DMCP", dmcp.is_dmcp(dmcp.fix(problem, fix_var2)))
+# print("Precision Is_DCP", dmcp.fix(problem, fix_var2).is_dcp())
+# print("Objective DMCP", dmcp.is_dmcp(objective.expr))
+# print("Is Problem DMCP? ", dmcp.is_dmcp(problem))
+# print("Number of variables: ", len(problem.variables()))
+
+#result = problem.solve(method = 'bcd', update = 'proximal', solver=cvx.MOSEK, max_iter=100)
+result = problem.solve(method = 'bcd', update = 'proximal', max_iter=100)


### PR DESCRIPTION
I've fixed multiple things for this PR:

1) if problem is dmcp yet the resulting minimal sets is empty (for some reason, this happens), I've automatically returned the minimal sets where everything except one variable is fixed. This is a quick fix. Would anyone have any ideas why result = [] for finding minimal sets even if it is dmcp?

2) I've fixed the proximal norm since, apparently, pnorm in CVXPY does not recognize 'fro' as an input anymore. I changed it to p=2.

3) Added initialization if var.sign  does not exist

4) I changed some minor things like accessing value of the max slack variable.